### PR TITLE
Merge 'devel' branch

### DIFF
--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -26,7 +26,7 @@ function! stoptypofile#check_typo()
     endif
     let prompt = "possible typo: really want to write to '"
     \           . file . "'?(y/n):"
-    if s:ask(prompt) =~? '^y\(es\)\=$'
+    if s:input(prompt) =~? '^y\(es\)\=$'
         execute writecmd
         let b:stoptypofile_nocheck = 1
     endif
@@ -34,7 +34,7 @@ endfunction
 
 " * inputsave() / inputrestore()
 " * highlight support
-function! s:ask(...) abort
+function! s:input(...) abort
     call inputsave()
     echohl WarningMsg
     try

--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -2,12 +2,26 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+" For jp106 keyboard: [, ]
+" For us101 keyboard: ], \
+let g:stoptypofile#check_pattern =
+\   get(g:, 'stoptypofile#check_pattern', '[[\]\\]$')
+" Some plugins are using special buffer name.
+let g:stoptypofile#ignore_pattern =
+\   get(g:, 'stoptypofile#ignore_pattern', '^\[qfreplace\]$')
 
 function! stoptypofile#check_typo()
     let file = expand('<afile>')
     let writecmd = 'write' . (v:cmdbang ? '!' : '') . ' ' . file
     if exists('b:stoptypofile_nocheck')
         execute writecmd
+        return
+    endif
+    if file !~# g:stoptypofile#check_pattern
+    \   || file =~# g:stoptypofile#ignore_pattern
+        if file !~# g:stoptypofile#check_pattern
+            execute writecmd
+        endif
         return
     endif
     let prompt = "possible typo: really want to write to '" . file . "'?(y/n):"

--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -24,7 +24,8 @@ function! stoptypofile#check_typo()
         endif
         return
     endif
-    let prompt = "possible typo: really want to write to '" . file . "'?(y/n):"
+    let prompt = "possible typo: really want to write to '"
+    \           . file . "'?(y/YES/n):"
     let input = s:ask(prompt)
     if input ==# 'YES'
         execute writecmd

--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -11,12 +11,14 @@ let g:stoptypofile#ignore_pattern =
 \   get(g:, 'stoptypofile#ignore_pattern', '^\[qfreplace\]$')
 
 function! stoptypofile#check_typo()
+    " Skip if a file is marked as temporarily ignored.
     let file = expand('<afile>')
     let writecmd = 'write' . (v:cmdbang ? '!' : '') . ' ' . file
     if s:is_ignored_file(file)
         execute writecmd
         return
     endif
+    " Skip a normal file or ignored file.
     if file !~# g:stoptypofile#check_pattern
     \   || file =~# g:stoptypofile#ignore_pattern
         if file !~# g:stoptypofile#check_pattern
@@ -24,6 +26,8 @@ function! stoptypofile#check_typo()
         endif
         return
     endif
+    " Ask and add to temporarily ignored files
+    " if a user input was 'yes'.
     let prompt = "possible typo: really want to write to '"
     \           . file . "'?(y/n):"
     if s:input(prompt) =~? '^y\(es\)\=$'
@@ -33,11 +37,13 @@ function! stoptypofile#check_typo()
 endfunction
 
 let s:ignored_files = {}
+" Returns non-zero if a file is temporarily ignored.
 function! s:is_ignored_file(file) abort
     let file = resolve(fnamemodify(a:file, ':p'))
     return has_key(s:ignored_files, file)
 endfunction
 
+" Mark a file as a temporarily ignored file.
 function! s:add_ignore_file(file) abort
     let file = resolve(fnamemodify(a:file, ':p'))
     let s:ignored_files[file] = 1

--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -13,7 +13,7 @@ let g:stoptypofile#ignore_pattern =
 function! stoptypofile#check_typo()
     let file = expand('<afile>')
     let writecmd = 'write' . (v:cmdbang ? '!' : '') . ' ' . file
-    if exists('b:stoptypofile_nocheck')
+    if s:is_ignored_file(file)
         execute writecmd
         return
     endif
@@ -28,8 +28,19 @@ function! stoptypofile#check_typo()
     \           . file . "'?(y/n):"
     if s:input(prompt) =~? '^y\(es\)\=$'
         execute writecmd
-        let b:stoptypofile_nocheck = 1
+        call s:add_ignore_file(file)
     endif
+endfunction
+
+let s:ignored_files = {}
+function! s:is_ignored_file(file) abort
+    let file = resolve(fnamemodify(a:file, ':p'))
+    return has_key(s:ignored_files, file)
+endfunction
+
+function! s:add_ignore_file(file) abort
+    let file = resolve(fnamemodify(a:file, ':p'))
+    let s:ignored_files[file] = 1
 endfunction
 
 " * inputsave() / inputrestore()

--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -25,13 +25,10 @@ function! stoptypofile#check_typo()
         return
     endif
     let prompt = "possible typo: really want to write to '"
-    \           . file . "'?(y/YES/n):"
-    let input = s:ask(prompt)
-    if input ==# 'YES'
+    \           . file . "'?(y/n):"
+    if s:ask(prompt) =~? '^y\(es\)\=$'
         execute writecmd
         let b:stoptypofile_nocheck = 1
-    elseif input =~? '^y\(es\)\=$'
-        execute writecmd
     endif
 endfunction
 

--- a/plugin/stoptypofile.vim
+++ b/plugin/stoptypofile.vim
@@ -12,10 +12,7 @@ set cpo&vim
 if !get(g:, 'stoptypofile_no_default_autocmd', 0)
     augroup stoptypofile
         autocmd!
-        " For jp106 keyboard
-        autocmd BufWriteCmd *[,*] call stoptypofile#check_typo()
-        " For us101 keyboard
-        " autocmd BufWriteCmd *],*\ call stoptypofile#check_typo()
+        autocmd BufWriteCmd * call stoptypofile#check_typo()
     augroup END
 endif
 

--- a/plugin/stoptypofile.vim
+++ b/plugin/stoptypofile.vim
@@ -13,6 +13,7 @@ if !get(g:, 'stoptypofile_no_default_autocmd', 0)
     augroup stoptypofile
         autocmd!
         autocmd BufWriteCmd * call stoptypofile#check_typo()
+        autocmd BufFilePost * unlet! b:stoptypofile_nocheck
     augroup END
 endif
 

--- a/plugin/stoptypofile.vim
+++ b/plugin/stoptypofile.vim
@@ -13,7 +13,6 @@ if !get(g:, 'stoptypofile_no_default_autocmd', 0)
     augroup stoptypofile
         autocmd!
         autocmd BufWriteCmd * call stoptypofile#check_typo()
-        autocmd BufFilePost * unlet! b:stoptypofile_nocheck
     augroup END
 endif
 


### PR DESCRIPTION
- Add `g:stoptypofile#check_pattern`
  - Support both JP106 and US101 keyboards by default
- Add `g:stoptypofile#ignore_pattern`
  - Add [vim-qfreplace](https://github.com/thinca/vim-qfreplace) support
- Drop support for "YES" input
  - Don't prompt for second `:write` or later by default
