### PR TITLE
Merge 'devel' branch

### DIFF
--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -2,10 +2,12 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-" For jp106 keyboard: [, ]
-" For us101 keyboard: ], \
+runtime! plugin/stoptypofile.vim
+
 let g:stoptypofile#check_pattern =
-\   get(g:, 'stoptypofile#check_pattern', '[[\]\\]$')
+\   get(g:, 'stoptypofile#check_pattern',
+\       '[' . escape(g:stoptypofile_autocmd_chars, ']-^:\') . ']$'
+\   )
 " Some plugins are using special buffer name.
 " * [qfreplace]
 " * fugitive://... (URI-like buffer name)

--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -14,8 +14,9 @@ let g:stoptypofile#ignore_pattern =
 
 function! stoptypofile#check_typo()
     " Skip if a file is marked as temporarily ignored.
-    let writecmd = 'write' . (v:cmdbang ? '!' : '')
     let file = expand('<afile>')
+    let writecmd = 'write' . (v:cmdbang ? '!' : '')
+    \               . ' `=' . string(file) . '`'
     if s:is_ignored_file(file)
         return s:do_write(writecmd)
     endif

--- a/autoload/stoptypofile.vim
+++ b/autoload/stoptypofile.vim
@@ -7,8 +7,10 @@ set cpo&vim
 let g:stoptypofile#check_pattern =
 \   get(g:, 'stoptypofile#check_pattern', '[[\]\\]$')
 " Some plugins are using special buffer name.
+" * [qfreplace]
+" * fugitive://... (URI-like buffer name)
 let g:stoptypofile#ignore_pattern =
-\   get(g:, 'stoptypofile#ignore_pattern', '^\[qfreplace\]$')
+\   get(g:, 'stoptypofile#ignore_pattern', '\v(^\[qfreplace\]$|^\w+://)')
 
 function! stoptypofile#check_typo()
     " Skip if a file is marked as temporarily ignored.
@@ -20,7 +22,7 @@ function! stoptypofile#check_typo()
     " Skip a normal file or ignored file.
     if file !~# g:stoptypofile#check_pattern
     \   || file =~# g:stoptypofile#ignore_pattern
-        if file !~# g:stoptypofile#check_pattern
+        if file !~# g:stoptypofile#ignore_pattern
             call s:do_write(writecmd)
         endif
         return

--- a/plugin/stoptypofile.vim
+++ b/plugin/stoptypofile.vim
@@ -10,10 +10,29 @@ set cpo&vim
 
 
 if !get(g:, 'stoptypofile_no_default_autocmd', 0)
+
+    " For jp106 keyboard: [, ]
+    " For us101 keyboard: ], \
+    let g:stoptypofile_autocmd_chars =
+    \   get(g:, 'stoptypofile_autocmd_chars', '[]\')
+
+    function! s:build_pattern(chars) abort
+        let patlist = split(a:chars, '\zs')
+        let patlist = map(patlist, 'v:val ==# "\\" ? "[\\\\]" : v:val')
+        let patlist = map(patlist, '"*" . v:val')
+        return join(patlist, ',')
+    endfunction
+
     augroup stoptypofile
         autocmd!
-        autocmd BufWriteCmd * call stoptypofile#check_typo()
+        " Add two spaces before 'call' because
+        " pattern[-1] can be '\'.
+        execute 'autocmd BufWriteCmd '
+        \     . s:build_pattern(g:stoptypofile_autocmd_chars)
+        \     . '  call stoptypofile#check_typo()'
     augroup END
+
+    delfunction s:build_pattern
 endif
 
 


### PR DESCRIPTION
- `:w]` can't :write to `]`
- URI-like buffer name cannot be handled properly (like `fugitive://...`)
- Register BufWriteCmd for only specific characters (`g:stoptypofile_autocmd_chars`)
  - `autocmd BufWriteCmd *` is too wide for autocommand scope because handling BufWriteCmd is highly sensitive.
